### PR TITLE
Set end of line as "LF" for all salesforce metadata

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,32 @@
+# ensure all salesforce code is normalised to LF upon commit
+*.cls text=auto eol=lf
+*.xml text=auto eol=lf
+*.profile text=auto eol=lf
+*.permissionset text=auto eol=lf
+*.layout text=auto eol=lf
+*.queue text=auto eol=lf
+*.app text=auto eol=lf
+*.component text=auto eol=lf
+*.email text=auto eol=lf
+*.page text=auto eol=lf
+*.object text=auto eol=lf
+*.report text=auto eol=lf
+*.site text=auto eol=lf
+*.tab text=auto eol=lf
+*.trigger text=auto eol=lf
+*.weblink text=auto eol=lf
+*.workflow text=auto eol=lf
+*.reportType text=auto eol=lf
+*.homePageLayout text=auto eol=lf
+*.homePageComponent text=auto eol=lf
+*.labels text=auto eol=lf
+*.group text=auto eol=lf
+*.quickAction text=auto eol=lf
+*.js text=auto eol=lf
+*.py text=auto eol=lf
+*.pl text=auto eol=lf
+*.csv text=auto eol=lf
+
+# More info
+# https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings#refreshing-a-repository-after-changing-line-endings
+# https://www.alyx-brett.net/blog/2015-01-15-Git-whitespace-with-SFDC


### PR DESCRIPTION
.gitattributes make sure that all salesforce metadata uses the same standard end of line LF