### PR TITLE
Set condition to always to publish artifacts despite pool failing

### DIFF
--- a/.azure-pipelines/env-operations/prepare-ci-pool.yml
+++ b/.azure-pipelines/env-operations/prepare-ci-pool.yml
@@ -92,6 +92,7 @@ steps:
 
 #Publish logs to artifacts             
     - task: PublishBuildArtifacts@1
+      condition: always()
       inputs:
             pathToPublish: .sfpowerscripts/prepare_logs/
             artifactName: PrepareLogs

--- a/.azure-pipelines/env-operations/prepare-dev-pool.yml
+++ b/.azure-pipelines/env-operations/prepare-dev-pool.yml
@@ -93,6 +93,7 @@ steps:
 
 #Publish logs to artifacts             
     - task: PublishBuildArtifacts@1
+      condition: always()
       inputs:
             pathToPublish: .sfpowerscripts/prepare_logs/
             artifactName: PrepareLogs


### PR DESCRIPTION
If pools fail, then pool artifacts should be published for troubleshooting