### PR TITLE
fix : allows build/publish from release/x branches

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,12 +1,19 @@
 ![image](https://gblobscdn.gitbook.com/assets%2F-MI39dIf1BuKlg_oSIG_%2F-MersLlsLMydZ6V7hfP-%2F-MersUtb9fBk1m9NMuMc%2Fflowdiagram_revised.png?alt=media&token=b613b0a8-99e3-4702-8f38-033cb1d7700d)
 
-This repo contains the follwing YAML based Azure Pipeline defintions
+This repo contains the follwing YAML based Github Pipeline defintions
 
 -  validate.yml
+
    Pull Request Validation Pipeline, that validates incoming changes against a scratch org fetched from the pool
    
-- build.yml
+- quickbuild-build-deploy.yml
+
    Pipeline that gets triggered on a merge to the trunk (main), resulting in building a set of packages, deploying to a dev sandbox ( and then build a set of validated packages and finally publish that to artifact repository
+
+- release-build-publish.yml
+
+   Triggered on a merge to a release/x branch. Assumes a change has been created/tested in main/dev (quickbuild-build-deploy.yml) and needs to be included in the release via a cherry-pick to the release branch. This builds and publishes off the relase branch making it avialble for the release pipeline.
+
 
 - release.yml
    A release pipeline that utilizes the release defintion to fetch artifacts from artifactory and then deploy to a sandbox 

--- a/.github/workflows/quickbuild-build-deploy.yml
+++ b/.github/workflows/quickbuild-build-deploy.yml
@@ -17,7 +17,6 @@ on:
   push:
     branches:
       - main
-      - release/**
 
 
   workflow_dispatch:
@@ -101,7 +100,7 @@ jobs:
     container: ghcr.io/dxatscale/sfpowerscripts
     needs: deploy
     concurrency: build 
-    if: github.ref == 'refs/heads/main' || 'refs/heads/release/*'
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -1,0 +1,74 @@
+# DX@Scale CI/CD Template for GitHub
+#----------------------------------------------------------------------------------------------------
+# Maintained by @aly76 for DX@Scale
+# Follows reference pipeline available at docs.dxatscale.io
+# 
+#-----------------------------------------------------------------------------------------------------
+# To know more about dxatscale, visit https://docs.dxatscale.io
+# To know more on sfpowerscripts, visit- https://sfpowerscripts.dxatscale.io/
+# To know more on sfpowerkit, visit- https://github.com/Accenture/sfpowerkit
+
+# This pipeline builds on a release branch. Assumes you've cherry-picked a fix from master (thats been tested in DEV etc). Makes the change available for release
+
+name: 'CI Pipeline - Release Build - Auto Triggered'
+
+
+on:
+  push:
+    branches:
+      - release/**
+
+
+  workflow_dispatch:
+
+
+
+#Set the environment variables for tracking metrics
+#env:
+  #SFPOWERSCRIPTS_NEWRELIC: 'true'
+  #SFPOWERSCRIPTS_NEWRELIC_API_KEY: '${{ secrets.NEWRELIC_INSIGHT_INSERT_KEYS }}'
+  #SFPOWERSCRIPTS_DATADOG: 'true'
+  #SFPOWERSCRIPTS_DATADOG_HOST: '${{ secrets.DATADOG_HOST }}'
+  #SFPOWERSCRIPTS_DATADOG_API_KEY: '${{ secrets.DATADOG_API_KEY }}'
+
+
+
+jobs:
+  buildAndPublish:
+    name: 'Build and Publish'
+    runs-on: ubuntu-latest
+    container: ghcr.io/dxatscale/sfpowerscripts
+    concurrency: build
+    if: contains(github.ref,'release') || github.ref == 'refs/heads/release/**'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: 'Authenticate Dev Hub'
+        run: |
+          echo "${{ secrets.DEVHUB_SFDX_AUTH_URL }}" > ./authfile
+          sfdx auth:sfdxurl:store -f authfile -a devhub
+
+      - name: 'Create packages'
+        id: sfpowerscripts-build
+        run: |
+          sfdx sfpowerscripts:orchestrator:build -v devhub --diffcheck --branch ${GITHUB_REF#refs/heads/} --buildnumber ${GITHUB_RUN_ID}
+
+      # Publish artifacts
+      - uses: actions/upload-artifact@v2
+        with:
+          node-version: '16.x'
+          name: build-artifacts
+          path: artifacts
+
+      - uses: actions/setup-node@v3
+        with:
+         registry-url: 'https://npm.pkg.github.com'
+         scope: '@${{ github.repository_owner }}'
+
+      - name: Publish
+        run: |
+          sfdx sfpowerscripts:orchestrator:publish -d artifacts --npm --scope @${{ github.repository_owner }}  --gittag --pushgittag
+        env:
+         NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
As disucssed with Azlam on slack
This assumes you cherry pick from main (which would see quickbuild and deploy to dev)
and re-builds/publishes on the releae branch to enable the release pipeline to move the change on